### PR TITLE
Adicionado wp-cli container e task para configurar o site

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,31 @@
-version: '2'
-
+version: "2"
 services:
-   db:
-     image: mysql:5.7
-     volumes:
-       - ./database:/var/lib/mysql
-     environment:
+  database-container:
+    image: mysql:5.7
+    ports:
+      - "8081:3306"
+    environment:
        MYSQL_ROOT_PASSWORD: wordpress
        MYSQL_DATABASE: wordpress
        MYSQL_USER: wordpress
        MYSQL_PASSWORD: wordpress
-   wordpress:
-     depends_on:
-       - db
-     volumes:
-       - ./wordpress:/var/www/html
-     image: wordpress:latest
-     ports:
-       - "8000:80"
-     restart: always
-     environment:
-       WORDPRESS_DB_HOST: db:3306
-       WORDPRESS_DB_PASSWORD: wordpress
+
+  wordpress-container:
+    image: wordpress
+    volumes:
+      - ./wordpress:/var/www/html
+    ports:
+      - "8080:80"
+    links:
+      - database-container:mysql
+    environment:
+      WORDPRESS_DB_PASSWORD: wordpress
+
+  wpcli-container:
+    image: tatemz/wp-cli
+    volumes_from:
+        - wordpress-container
+    links:
+        - database-container:mysql
+    entrypoint: wp  
+    command: "--info"

--- a/package.json
+++ b/package.json
@@ -4,13 +4,18 @@
   "description": "Código utilizado para o Workshop Wordpress PHP Experience 2017",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "wp-site-install": "docker-compose run --rm wpcli-container core install --title=PHPExperience --url=localhost:8080 --admin_user=wordpress --admin_password=wordpress --admin_email=lazaro.fernandes@lambda3.com.br --skip-email"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fabiodamasceno/workshop-wordpress-php-experience.git"
   },
   "author": "fábio damasceno",
+  "contributors": [{
+    "name": "Lazaro Fernandes Lima Suleiman",
+    "email": "lazaro.fl@gmail.com"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/fabiodamasceno/workshop-wordpress-php-experience/issues"


### PR DESCRIPTION
- volume do database não precisa estar exposto
- habilitada uma porta de comunicação para o database mysql
- alterado o uso de depends_on para links, fazendo que com os containers possua os mesmos host names.
- aplicado container de wp-cli com acessa ao container de banco de dados e com volume compartilhado com o wordpress-container
- adicionada task do `npm` para instação do wordpress: `wp-site-install` 